### PR TITLE
Make setup-env.sh sourceable from any directory

### DIFF
--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
-LLVM_BUILD=$PWD/tapir/build
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+LLVM_BUILD=$DIR/tapir/build
 export PATH=$LLVM_BUILD/bin:$PATH


### PR DESCRIPTION
After the initial build, it is rather cumbersome to have to `cd Tapir-Meta && source setup-env.sh &&  cd -`.
This PR fixes the problem so that one can `source setup-env.sh` from any directory.